### PR TITLE
Execute CI workflows for branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ name: build
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   make:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,8 +3,6 @@ name: lint
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   git-diff--check:


### PR DESCRIPTION
This change modifies the GitHub Actions workflow configuration to
execute on the (push to a) branch in addition to a pull request.