### PR TITLE
Use consistent rule for building packages

### DIFF
--- a/Makefile.mk
+++ b/Makefile.mk
@@ -54,8 +54,16 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
        $(shell find . -mindepth 2 -name "*.tex")
 	$(compile-doc)
 
+%.sty: directory = $(dir $<)
 %.sty: %.ins %.dtx
-	$(TEX) -draftmode $<
+	$(TEX) -draftmode -output-directory=$(directory) $<
+
+# include packages in the search path
+packages != $(MAKE) --directory=$(CWD) --quiet list 2> /dev/null
+
+vpath %.ins $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))
+vpath %.sty $(CWD):$(addprefix $(CWD)/,$(packages))
 
 
 derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.toc *.vrb

--- a/beamer/themes/theme/engineering.jhu.edu/Makefile
+++ b/beamer/themes/theme/engineering.jhu.edu/Makefile
@@ -5,13 +5,9 @@ default: beamerthemeengineering.jhu.edu.sty beamerthemeengineering.jhu.edu.pdf
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemeengineering.jhu.edu.sty: | beamerthemejhu.edu.sty
-beamerthemeengineering.jhu.edu.pdf: beamerthemeengineering.jhu.edu.sty example.pdf | minted
+beamerthemeengineering.jhu.edu.sty:
+beamerthemeengineering.jhu.edu.pdf: beamerthemejhu.edu.sty beamerthemeengineering.jhu.edu.sty example.pdf | minted
 
 example.pdf: beamerthemeengineering.jhu.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamerthemejhu.edu.sty:
-	$(MAKE) --directory=../jhu.edu $@

--- a/beamer/themes/theme/ep.jhu.edu/Makefile
+++ b/beamer/themes/theme/ep.jhu.edu/Makefile
@@ -5,16 +5,12 @@ default: beamerthemeep.jhu.edu.sty beamerthemeep.jhu.edu.pdf
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemeep.jhu.edu.sty: | beamerthemeengineering.jhu.edu.sty whiting.logo.small.horizontal.white.eps
-beamerthemeep.jhu.edu.pdf: beamerthemeep.jhu.edu.sty example.pdf | minted
+beamerthemeep.jhu.edu.sty: | whiting.logo.small.horizontal.white.eps
+beamerthemeep.jhu.edu.pdf: beamercolorthemebluejay.sty beamerthemejhu.edu.sty beamerthemeengineering.jhu.edu.sty beamerthemeep.jhu.edu.sty example.pdf | minted
 
 example.pdf: beamerthemeep.jhu.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamerthemeengineering.jhu.edu.sty:
-	$(MAKE) --directory=../engineering.jhu.edu $@
 
 whiting.logo.small.horizontal.white.eps: | beamerthemeengineering.jhu.edu.sty
 	cp ../engineering.jhu.edu/$@ $@

--- a/beamer/themes/theme/jhu.edu/Makefile
+++ b/beamer/themes/theme/jhu.edu/Makefile
@@ -5,13 +5,9 @@ default: beamerthemejhu.edu.sty beamerthemejhu.edu.pdf
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemejhu.edu.sty: | beamercolorthemebluejay.sty
-beamerthemejhu.edu.pdf: beamerthemejhu.edu.sty example.pdf | minted
+beamerthemejhu.edu.sty:
+beamerthemejhu.edu.pdf: beamercolorthemebluejay.sty beamerthemejhu.edu.sty example.pdf | minted
 
 example.pdf: beamerthemejhu.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamercolorthemebluejay.sty:
-	$(MAKE) --directory=../../color/bluejay $@

--- a/beamer/themes/theme/jhuapl.edu/Makefile
+++ b/beamer/themes/theme/jhuapl.edu/Makefile
@@ -5,13 +5,9 @@ default: beamerthemejhuapl.edu.sty beamerthemejhuapl.edu.pdf
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-beamerthemejhuapl.edu.sty: | beamerthemejhu.edu.sty
-beamerthemejhuapl.edu.pdf: beamerthemejhuapl.edu.sty example.pdf | minted
+beamerthemejhuapl.edu.sty:
+beamerthemejhuapl.edu.pdf: beamercolorthemebluejay.sty beamerthemejhu.edu.sty beamerthemejhuapl.edu.sty example.pdf | minted
 
 example.pdf: beamerthemejhuapl.edu.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
-
-# fall-back for Beamer themes
-beamerthemejhu.edu.sty:
-	$(MAKE) --directory=../jhu.edu $@

--- a/engineering.jhu.edu/syllabus/Makefile
+++ b/engineering.jhu.edu/syllabus/Makefile
@@ -9,3 +9,5 @@ syllabus.sty:
 syllabus.pdf: syllabus.sty | minted
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
+
+vpath %.sty  # clear search path for *.sty to avoid conflicts

--- a/ep.jhu.edu/syllabus/Makefile
+++ b/ep.jhu.edu/syllabus/Makefile
@@ -5,3 +5,5 @@ syllabus.sty:
 syllabus.pdf: syllabus.sty
 
 include $(shell git rev-parse --show-toplevel)/Makefile.mk
+
+vpath %.sty  # clear search path for *.sty to avoid conflicts


### PR DESCRIPTION
This change removes the order-only prerequisites used to build other
packages (in this repository) in favor of "normal" prerequisites.