### PR TITLE
Strip braces for graphics file with dots

### DIFF
--- a/beamer/themes/theme/ep.jhu.edu/beamerthemeep.jhu.edu.dtx
+++ b/beamer/themes/theme/ep.jhu.edu/beamerthemeep.jhu.edu.dtx
@@ -174,7 +174,7 @@
         clip,
         trim=40 35 40 35,
         width=\linewidth,
-    ]{whiting.logo.small.horizontal.white}
+    ]{{whiting.logo.small.horizontal.white}.eps}
   \end{minipage}%
   \hfill%
   \begin{minipage}[T]{0.115\paperwidth}

--- a/beamer/themes/theme/ep.jhu.edu/beamerthemeep.jhu.edu.dtx
+++ b/beamer/themes/theme/ep.jhu.edu/beamerthemeep.jhu.edu.dtx
@@ -174,7 +174,7 @@
         clip,
         trim=40 35 40 35,
         width=\linewidth,
-    ]{{{whiting.logo.small.horizontal.white}}}
+    ]{whiting.logo.small.horizontal.white}
   \end{minipage}%
   \hfill%
   \begin{minipage}[T]{0.115\paperwidth}


### PR DESCRIPTION
This change removes the special handling for image file names that
contain dots, which is no longer necessary due to LaTeX kernel
changes.