### PR TITLE
Remove times package from example

### DIFF
--- a/beamer/themes/beamerthemeexamplebase.tex
+++ b/beamer/themes/beamerthemeexamplebase.tex
@@ -11,8 +11,6 @@
 \beamertemplatesolidbackgroundcolor{black!5}
 \beamertemplatetransparentcovered
 
-\usepackage{times}
-
 \title{There Is No Largest Prime Number}
 \subtitle{With an introduction to a new proof technique}
 

--- a/beamer/themes/color/bluejay/example.tex
+++ b/beamer/themes/color/bluejay/example.tex
@@ -1,5 +1,7 @@
 \documentclass{beamer}
 
+\usepackage[scaled]{helvet}
+
 
 % beamer
 \usecolortheme{bluejay}

--- a/beamer/themes/theme/engineering.jhu.edu/example.tex
+++ b/beamer/themes/theme/engineering.jhu.edu/example.tex
@@ -1,5 +1,7 @@
 \documentclass{beamer}
 
+\usepackage[scaled]{helvet}
+
 
 % beamer
 \usetheme{engineering.jhu.edu}

--- a/beamer/themes/theme/ep.jhu.edu/example.tex
+++ b/beamer/themes/theme/ep.jhu.edu/example.tex
@@ -1,5 +1,7 @@
 \documentclass{beamer}
 
+\usepackage[scaled]{helvet}
+
 
 % beamer
 \usetheme{ep.jhu.edu}

--- a/beamer/themes/theme/jhu.edu/example.tex
+++ b/beamer/themes/theme/jhu.edu/example.tex
@@ -1,5 +1,7 @@
 \documentclass{beamer}
 
+\usepackage[scaled]{helvet}
+
 
 % beamer
 \usetheme{jhu.edu}

--- a/beamer/themes/theme/jhuapl.edu/example.tex
+++ b/beamer/themes/theme/jhuapl.edu/example.tex
@@ -1,5 +1,7 @@
 \documentclass{beamer}
 
+\usepackage[scaled]{helvet}
+
 
 % beamer
 \usetheme{jhuapl.edu}


### PR DESCRIPTION
The inclusion of the times package prevents examples of Beamer
presentation themes from using a typeface specified by the theme.
Hence, this change removes the use of the times package.

A similar change has been made in the Beamer repository:
josephwright/beamer#629.